### PR TITLE
Fix comparison between two `Check` types

### DIFF
--- a/strck/src/lib.rs
+++ b/strck/src/lib.rs
@@ -501,7 +501,7 @@ mod tests {
     #[test]
     fn test_debug_impl() {
         let this = "this".ck::<NoInvariant>().unwrap();
-        let fmt_debug = format!("{:?}", this);
+        let fmt_debug = format!("{this:?}");
 
         assert_eq!(fmt_debug, "\"this\"");
     }

--- a/strck/src/lib.rs
+++ b/strck/src/lib.rs
@@ -505,4 +505,54 @@ mod tests {
 
         assert_eq!(fmt_debug, "\"this\"");
     }
+
+    #[test]
+    fn test_ck_partial_eq() {
+        let this = "this".ck::<NoInvariant>().unwrap();
+        let still_this = "this".ck::<NoInvariant>().unwrap();
+        let other = "other".ck::<NoInvariant>().unwrap();
+
+        // With other different instance
+        assert_ne!(this, other);
+        assert_ne!(this, &other);
+        assert_ne!(&this, other);
+        assert_ne!(&this, &other);
+
+        // With other equal instance
+        assert_eq!(this, still_this);
+        assert_eq!(this, &still_this);
+        assert_eq!(&this, still_this);
+        assert_eq!(&this, &still_this);
+
+        // With itself
+        assert_eq!(this, this);
+        assert_eq!(this, &this);
+        assert_eq!(&this, this);
+        assert_eq!(&this, &this);
+    }
+
+    #[test]
+    fn test_check_partial_eq() {
+        let this = "this".check::<NoInvariant>().unwrap();
+        let still_this = "this".check::<NoInvariant>().unwrap();
+        let other = "other".check::<NoInvariant>().unwrap();
+
+        // With other different instance
+        assert_ne!(this, other);
+        assert_ne!(this, &other);
+        assert_ne!(&this, other);
+        assert_ne!(&this, &other);
+
+        // With other equal instance
+        assert_eq!(this, still_this);
+        assert_eq!(this, &still_this);
+        assert_eq!(&this, still_this);
+        assert_eq!(&this, &still_this);
+
+        // With itself
+        assert_eq!(this, this);
+        assert_eq!(this, &this);
+        assert_eq!(&this, this);
+        assert_eq!(&this, &this);
+    }
 }

--- a/strck/src/lib.rs
+++ b/strck/src/lib.rs
@@ -292,7 +292,7 @@ where
     B2: AsRef<str>,
 {
     fn eq(&self, other: &Check<I, B2>) -> bool {
-        self == other
+        self.as_str() == other.as_str()
     }
 }
 

--- a/strck/src/serde.rs
+++ b/strck/src/serde.rs
@@ -69,7 +69,7 @@ mod tests {
 
         fn get() -> Player<'static> {
             let ser = r#"{"username":"qnn","level":100}"#;
-            serde_json::from_str(&ser).unwrap()
+            serde_json::from_str(ser).unwrap()
         }
 
         let de = get();


### PR DESCRIPTION
This PR fixes #2 by modifying the `PartialEq` impl for `Check` when comparing to another `Check` (even if it is the same instance). 
The previous impl was creating an infinite loop as it was calling itself continuously by `self == other`, resulting eventually in a stack overflow.

Also fixed some minor clippy lints and added tests for `PartialEq` for both `Check` and `Ck`.
